### PR TITLE
Spacy fixes with longs documents

### DIFF
--- a/python-lib/spacy_tokenizer.py
+++ b/python-lib/spacy_tokenizer.py
@@ -119,7 +119,7 @@ class MultilingualTokenizer:
 
     DEFAULT_BATCH_SIZE = 1000
     MAX_NUM_CHARACTERS = 10 ** 7
-    DEFAULT_NUM_PROCESS = 2
+    DEFAULT_NUM_PROCESS = 1
     DEFAULT_FILTER_TOKEN_ATTRIBUTES = {
         "is_space": "Whitespace",
         "is_punct": "Punctuation",

--- a/tests/python/unit/test_spacy_tokenizer.py
+++ b/tests/python/unit/test_spacy_tokenizer.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# This is a test file intended to be used with pytest
+# pytest automatically runs all the function starting with "test_"
+# see https://docs.pytest.org for more information
+
+import os
+
+import pandas as pd
+
+from spacy_tokenizer import MultilingualTokenizer
+
+
+def test_tokenize_df_english():
+    input_df = pd.DataFrame({"input_text": ["I hope nothing. I fear nothing. I am free. 💩 😂 #OMG"]})
+    tokenizer = MultilingualTokenizer()
+    output_df = tokenizer.tokenize_df(df=input_df, text_column="input_text", language="en")
+    tokenized_document = output_df[tokenizer.tokenized_column][0]
+    assert len(tokenized_document) == 15
+
+
+def test_tokenize_df_japanese():
+    input_df = pd.DataFrame({"input_text": ["期一会。 異体同心。 そうです。"]})
+    tokenizer = MultilingualTokenizer()
+    output_df = tokenizer.tokenize_df(df=input_df, text_column="input_text", language="ja")
+    tokenized_document = output_df[tokenizer.tokenized_column][0]
+    assert len(tokenized_document) == 9
+
+
+def test_tokenize_df_multilingual():
+    input_df = pd.DataFrame(
+        {
+            "input_text": [
+                "I hope nothing. I fear nothing. I am free.",
+                " Les sanglots longs des violons d'automne",
+                "子曰：“學而不思則罔，思而不學則殆。”",
+                "期一会。 異体同心。 そうです。",
+            ],
+            "language": ["en", "fr", "zh", "ja"],
+        }
+    )
+    tokenizer = MultilingualTokenizer()
+    output_df = tokenizer.tokenize_df(df=input_df, text_column="input_text", language_column="language")
+    tokenized_documents = output_df[tokenizer.tokenized_column]
+    tokenized_documents_length = [len(doc) for doc in tokenized_documents]
+    assert tokenized_documents_length == [12, 8, 13, 9]
+
+
+def test_tokenize_df_long_text():
+    input_df = pd.DataFrame({"input_text": ["Long text"]})
+    tokenizer = MultilingualTokenizer(max_num_characters=1)
+    with pytest.raises(ValueError):
+        tokenizer.tokenize_df(df=input_df, text_column="input_text", language="en")

--- a/tests/python/unit/test_spacy_tokenizer.py
+++ b/tests/python/unit/test_spacy_tokenizer.py
@@ -44,7 +44,7 @@ def test_tokenize_df_multilingual():
     output_df = tokenizer.tokenize_df(df=input_df, text_column="input_text", language_column="language")
     tokenized_documents = output_df[tokenizer.tokenized_column]
     tokenized_documents_length = [len(doc) for doc in tokenized_documents]
-    assert tokenized_documents_length == [12, 8, 13, 9]
+    assert tokenized_documents_length == [12, 8, 19, 9]
 
 
 def test_tokenize_df_long_text():

--- a/tests/python/unit/test_spacy_tokenizer.py
+++ b/tests/python/unit/test_spacy_tokenizer.py
@@ -6,6 +6,7 @@
 import os
 
 import pytest
+
 import pandas as pd
 
 from spacy_tokenizer import MultilingualTokenizer

--- a/tests/python/unit/test_spacy_tokenizer.py
+++ b/tests/python/unit/test_spacy_tokenizer.py
@@ -5,6 +5,7 @@
 
 import os
 
+import pytest
 import pandas as pd
 
 from spacy_tokenizer import MultilingualTokenizer


### PR DESCRIPTION
[ch63906](https://app.clubhouse.io/dataiku/story/63906/increase-nlp-max-length-to-10m-characters)
[ch63920](https://app.clubhouse.io/dataiku/story/63920/recipe-keeps-running-when-spacy-has-crashed-when-a-too-large-dataset-is-used-as-an-input)