### PR TITLE
Don't allow spacy3.8 and further

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,4 +1,4 @@
-spacy[lookups,ja,th]~=3.0
+spacy[lookups,ja,th]<3.8
 regex==2020.11.13
 emoji==1.2.0
 pymorphy2==0.9.1


### PR DESCRIPTION
Spacy3.8 bootstraps a requirements chain that needs numpy2, but we're not ready for that yet.

This updated code env still won't build because on sudachipy on macOS, but it's okay on unix systems.