### PR TITLE
Pin sudachipy for python 3.7 and 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 0.2.2](https://github.com/dataiku/dss-plugin-nlp-analysis/releases/tag/v0.2.2)
+- Fix broken dependency chain on python v3.7 and v3.8 due to a new sudachipy version released
+
 ## [Version 0.2.1](https://github.com/dataiku/dss-plugin-nlp-analysis/releases/tag/v0.2.1)
 - Fix broken dependency chain due to a new spacy version released
 

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -8,6 +8,7 @@ pyvi==0.1
 jieba==0.42.1
 fastcore==1.3.19
 sudachipy==0.6.0; python_version == '3.6'
+sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9'
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
 https://github.com/explosion/spacy-models/releases/download/es_core_news_sm-3.0.0/es_core_news_sm-3.0.0.tar.gz#egg=es_core_news_sm
 https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.0.0/zh_core_web_sm-3.0.0.tar.gz#egg=zh_core_web_sm

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -8,7 +8,8 @@ pyvi==0.1
 jieba==0.42.1
 fastcore==1.3.19
 sudachipy==0.6.0; python_version == '3.6'
-sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9'
+sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9' and platform_system != "Darwin"
+sudachipy<0.6.9; python_version >= '3.7' and python_version < '3.9' and platform_system == "Darwin"
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
 https://github.com/explosion/spacy-models/releases/download/es_core_news_sm-3.0.0/es_core_news_sm-3.0.0.tar.gz#egg=es_core_news_sm
 https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.0.0/zh_core_web_sm-3.0.0.tar.gz#egg=zh_core_web_sm

--- a/plugin.json
+++ b/plugin.json
@@ -1,11 +1,11 @@
 {
     "id": "nlp-analysis",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "meta": {
         "label": "Text Analysis",
         "category": "Natural Language Processing",
         "description": "Analyze text data with ontology tagging",
-        "author": "Dataiku (Jane BELLAICHE, Alex COMBESSIE)",
+        "author": "Dataiku (Jane BELLAICHE, CaraML)",
         "icon": "icon-list-alt",
         "licenseInfo": "Apache Software License",
         "url": "https://www.dataiku.com/product/plugins/nlp-analysis/",


### PR DESCRIPTION
Sudachipy released on the 10th of january 2025 version 0.6.10, with no wheels for python3.8 and before : 

https://pypi.org/project/SudachiPy/0.6.10/#files